### PR TITLE
Added missing dependencies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Make sure your server meets the following requirements.
 -   MySQL Server 5.7.8+ , Mariadb 10.3.2+ or PostgreSQL
 -   Composer installed 2.0+
 -   PHP Version 8.0.x+
+-   Redis 3.0+
 
 
 ### PHP extensions
@@ -62,10 +63,11 @@ Make sure you have the following php extensions enabled
 
 ```
 bz2, curl, date, dom, exif, gd, gettext, grpc,
-imagick, intl, json, libxml, mbstring, mysqli, mysqlnd, openssl, PDO,
-pdo_mysql, posix, protobuf, soap, sqlite3, xml, xmlreader, xmlwriter
+imagick, intl, json, libxml, mbstring, mysqli, mysqlnd, openssl, pcntl, PDO,
+pdo_mysql, posix, protobuf, redis, soap, sqlite3, xml, xmlreader, xmlwriter
 xsl, zip, zlib
 ```
+If you face issues while enabaling these extension, visit [here](https://www.php.net/manual/en/install.pecl.windows.php)
 
 ## Installation
 


### PR DESCRIPTION
## Description: 
while setting up the project in Windows, I face some issues due to some missing PHP extensions and dependencies which are not mentioned in the README. Updating these to the README which will make easier for others to setup.

## Changes 
- Added extensions like `pcntl`, `redis` in the extensions-to-enable section which are require while setup (SS:1)
- Provided documentation link for downloading and enabling extensions.
- Added `Redis` as a host requirement which is required while seeding data. (SS:2)
### SS:1
![missing](https://user-images.githubusercontent.com/77141674/229288689-9c46e4b1-7b7c-4e8f-8728-95019e052d76.png)

### SS:2
![redisexception](https://user-images.githubusercontent.com/77141674/229288723-1f026af9-3107-47bb-bdd7-bd033aaf3325.png)



