### PR TITLE
make only the form part of the login pages scrollable

### DIFF
--- a/resources/app/layouts/AuthLayout.vue
+++ b/resources/app/layouts/AuthLayout.vue
@@ -3,7 +3,7 @@
         <FlashMessages/>
         <div class="w-full h-screen flex">
             <img :src="'/images/main_bg.jpg'" alt="background" class="object-cover object-center h-screen w-7/12">
-            <div class="bg-white overflow-scroll-container flex flex-col  w-5/12 shadow-lg border-solid border-t-4 border-orange-600">
+            <div class="h-screen overflow-x-hidden overflow-y-scroll bg-white overflow-scroll-container flex flex-col  w-5/12 shadow-lg border-solid border-t-4 border-orange-600">
                 <div class="flex rtl:ml-10 ltr:mr-10 my-4 justify-end">
                     <LanguageSwitcher/>
                 </div>


### PR DESCRIPTION
**Description**

The login page scrolls completely and leaves an empty space under the image, which is not very aesthetic. 

**Solution**

I applied a `h-screen` class to the form container and a `scroll-x-hidden` class to prevent vertical scrolling. Then I added the `overflow-y-scroll` class to the div containing the form so that the scroll bar appears inside and not in the body.

**Files Changed**

`resources/app/layouts/AuthLayout.vue`

**Login Page Before**

<img width="960" alt="Screenshot 2023-04-04 042721" src="https://user-images.githubusercontent.com/48652493/229683700-c123dbb8-887b-4603-ad2b-921bc4004862.png">

**Login Page After**

https://user-images.githubusercontent.com/48652493/229684113-1f678e3b-635f-4f61-aa55-3812174083bc.mp4
